### PR TITLE
fix: dimtype_eltype

### DIFF
--- a/src/timeseries/operations.jl
+++ b/src/timeseries/operations.jl
@@ -1,6 +1,6 @@
-dimtype_eltype(d) = (basetypeof(d), nonmissingtype(eltype(d)))
-dimtype_eltype(A, query) = dimtype_eltype(dims(A, query))
-dimtype_eltype(A, ::Nothing) = dimtype_eltype(A, TimeDim)
+dimtype_eltype(d) = (basetypeof(d), eltype(d))
+dimtype_eltype(A, query) = dimtype_eltype(dims(A, something(query, TimeDim)))
+# dimtype_eltype(A, ::Nothing) = dimtype_eltype(A, TimeDim)
 
 function tsort(A; query=nothing, rev=false)
     tdim = timedim(A, query)
@@ -20,7 +20,6 @@ Clip a dimension or `DimArray` to a time range `[t0, t1]`.
 For unordered dimensions, the dimension should be sorted before clipping (see [`tsort`](@ref)).
 """
 function tclip(A::AbstractDimArray, t0, t1; query=nothing)
-    query = something(query, TimeDim)
     Dim, T = dimtype_eltype(A, query)
     return A[Dim(T(t0) .. T(t1))]
 end
@@ -34,7 +33,6 @@ View a dimension or `DimArray` in time range `[t0, t1]`.
 """
 tview(d, t0, t1) = @view d[DateTime(t0)..DateTime(t1)]
 function tview(da::AbstractDimArray, t0, t1; query=nothing)
-    query = something(query, TimeDim)
     Dim, T = dimtype_eltype(da, query)
     return @view da[Dim(T(t0) .. T(t1))]
 end


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Remove redundant `query` parameter assignment in time operations

- Fix `dimtype_eltype` function calls by removing unnecessary defaults


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>operations.jl</strong><dd><code>Remove redundant query parameter assignments</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/timeseries/operations.jl

<li>Remove <code>query = something(query, TimeDim)</code> line from <code>tclip</code> function<br> <li> Remove <code>query = something(query, TimeDim)</code> line from <code>tview</code> function<br> <li> Simplify parameter handling in both time operation functions


</details>


  </td>
  <td><a href="https://github.com/JuliaSpacePhysics/SPEDAS.jl/pull/65/files#diff-8a06b5fa7d3219c250840c6b5e58a48b55e7d7ce178bd9cce0eeda7f6a7cab9f">+0/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>